### PR TITLE
Add a Travis badge (with build status) to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rails 12factor
+# Rails 12factor [![Build Status](https://travis-ci.org/heroku/rails_12factor.png)](https://travis-ci.org/heroku/rails_12factor)
 
 Makes running your Rails app easier. Based on the ideas behind [12factor.net](http://12factor.net)
 


### PR DESCRIPTION
Pull request #4 added a simple test suite that ran on Travis. However, the readme doesn't link to the Travis project or show its status. This commit adds a standard Travis build status badge to the top of the readme (which is also a link).
