### PR TITLE
Remove rails_serve_static_assets

### DIFF
--- a/lib/rails_12factor.rb
+++ b/lib/rails_12factor.rb
@@ -1,5 +1,4 @@
 module Rails12factor
 end
 
-require 'rails_serve_static_assets'
 require 'rails_stdout_logging'

--- a/rails_12factor.gemspec
+++ b/rails_12factor.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "rake"
-  gem.add_dependency "rails_serve_static_assets"
   gem.add_dependency "rails_stdout_logging"
 end

--- a/test/test_rails_12factor.rb
+++ b/test/test_rails_12factor.rb
@@ -2,10 +2,8 @@ require 'helper'
 
 class TestRails12factor < Minitest::Test
   def test_gem_dependencies_are_loaded
-    assert !defined?(RailsServeStaticAssets)
     assert !defined?(RailsStdoutLogging)
     require 'rails_12factor'
-    assert defined?(RailsServeStaticAssets)
     assert defined?(RailsStdoutLogging)
   end
 end


### PR DESCRIPTION
In Rails 4.2 enabling the static file server by setting $RAILS_SERVE_STATIC_FILES is builtin. https://github.com/rails/rails/pull/18100/files