### PR TITLE
Set STDOUT.sync = true for parity with rails_stdout_logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ your `production.rb` file:
 config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
 if ENV["RAILS_LOG_TO_STDOUT"].present?
+  STDOUT.sync = true
   logger           = ActiveSupport::Logger.new(STDOUT)
   logger.formatter = config.log_formatter
   config.logger = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
I'm not sure why it is more important on Heroku to sync STDOUT than any other time, or if the setting is there to prevent surprising out of order messages and there is a negligible performance penalty when not in a tty.

I made this PR in part to ask a question about the importance of this setting.

I am currently replacing `rails_stdout_logging` with `rails_semantic_logger`, and was overriding the rails_stdout_logging logger:

```ruby
  # turn off file logging
  config.rails_semantic_logger.add_file_appender = false
  # configure logging to STDOUT like rails_stdout_logging (i.e. 'io: STDOUT' and 'STDOUT.sync = true')
  config.semantic_logger.add_appender(io: STDOUT, level: config.log_level, formatter: config.rails_semantic_logger.format)
  STDOUT.sync = true
  # no need for rails_stdout_logging (via rails_12factor), but heroku still requires it
  fail "remove the block which overrides the RailsStdoutLogging override" unless defined?(RailsStdoutLogging)
  initializer(:override_rails_stdout_logging_logger, after: :rails_stdout_logging) do
    ::Rails.logger = config.logger = SemanticLogger[Rails]
  end
```

So that now I have

```ruby
    # per rails_12factor, example of ussing ENV var to need for rails_stdout_logging
    # On Heroku, RAILS_LOG_TO_STDOUT=true
    if ENV["RAILS_LOG_TO_STDOUT"].present?
      # turn off file logging
      config.rails_semantic_logger.add_file_appender = false
      # configure logging to STDOUT like rails_stdout_logging (i.e. 'io: STDOUT' and 'STDOUT.sync = true')
      config.semantic_logger.add_appender(io: STDOUT, level: config.log_level, formatter: config.rails_semantic_logger.format)
      STDOUT.sync = true
    end
```